### PR TITLE
fix function variable shadows a class variable

### DIFF
--- a/ImGuiProfilerRenderer.h
+++ b/ImGuiProfilerRenderer.h
@@ -144,7 +144,6 @@ namespace ImGuiUtils
     {
       float markerLeftRectMargin = 3.0f;
       float markerLeftRectWidth = 5.0f;
-      float maxFrameTime = 1.0f / 30.0f;
       float markerMidWidth = 30.0f;
       float markerRightRectWidth = 10.0f;
       float markerRigthRectMargin = 3.0f;


### PR DESCRIPTION
maxFrameTime is already defiend in the class scope and the legends doesn't render correctly when u change the variable in the class scope